### PR TITLE
render index on base path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -110,7 +110,7 @@ exports.register = function (plugin, options, next) {
 
   plugin.route({
     method: 'GET',
-    path: '/index.html',
+    path: '/',
     config: {
       handler: internals.handler
     }


### PR DESCRIPTION
It was found while hosting multiple connections with hapi that if the trailing slash was not included it would try to go back past the prefix and render index.html.

I tested this with and without setting route.prefix options and it fixes the issue; and doesn't display index.html in the url.

Signed-off-by: Ryan Wilson <syndicated.life@gmail.com>