### PR TITLE
allow configuring auth

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,25 @@ var optionsSchema = Joi.object({
     valuePrefix: Joi.string().optional(),
     defaultValue: Joi.string().optional(),
     placeholder: Joi.string().optional()
-  }).optional()
+  }).optional(),
+  auth: Joi.alternatives([
+    Joi.string(),
+    Joi.object({
+      mode: Joi.string().valid('required', 'optional', 'try'),
+      scope: Joi.alternatives([
+        Joi.string(),
+        Joi.array()
+      ])
+        .allow(false),
+      entity: Joi.string().valid('user', 'app', 'any'),
+      strategy: Joi.string(),
+      strategies: Joi.array().min(1),
+      payload: [
+        Joi.string().valid('required', 'optional'),
+        Joi.boolean()
+      ]
+    })
+  ]).allow(false)
 })
 
 var defaultOptions = {
@@ -112,7 +130,8 @@ exports.register = function (plugin, options, next) {
     method: 'GET',
     path: '/index.html',
     config: {
-      handler: internals.handler
+      handler: internals.handler,
+      auth: settings.auth
     }
   })
 
@@ -129,7 +148,8 @@ exports.register = function (plugin, options, next) {
           index: true,
           listing: false
         }
-      }
+      },
+      auth: settings.auth
     }
   })
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hapi-swaggered-ui",
   "description": "Easy swagger-ui drop-in plugin for hapi to be used with hapi-swaggered.",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "author": "Timo Behrmann",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allow plugin `auth` to be configured separately from app's `auth` configuration. (i.e. allow documentation to be viewed by public without authentication)