### PR TITLE
Validate path parameter of the docs path

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -189,6 +189,11 @@ function register (plugin, options) {
       method: 'GET',
       path: path,
       options: {
+        validate: {
+          params: {
+            path: Joi.string()
+          }
+        },
         handler: {
           directory: {
             path: swaggerUiPath,


### PR DESCRIPTION
Lack of it leads to online.swagger.io validator
consider the generated docs invalid