### PR TITLE
Do not load fonts from the third-party CDN

### DIFF
--- a/templates/error.hbs
+++ b/templates/error.hbs
@@ -3,7 +3,6 @@
 <head>
     <title>Error - {{title}}</title>
     <meta name="hapi-swaggered-version" content="{{version}}">
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
     <link rel="stylesheet" type="text/css" href="{{routePrefix}}/swagger-ui.css" >
     <link rel="icon" type="image/png" href="{{routePrefix}}/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="{{routePrefix}}/favicon-16x16.png" sizes="16x16" />

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -5,7 +5,6 @@
   <meta charset="UTF-8">
   <title>{{title}}</title>
   <meta name="hapi-swaggered-version" content="{{version}}">
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="{{routePrefix}}/swagger-ui.css" >
   <link rel="icon" type="image/png" href="{{routePrefix}}/favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="{{routePrefix}}/favicon-16x16.png" sizes="16x16" />


### PR DESCRIPTION
Following the change in the swagger-ui:
https://github.com/swagger-api/swagger-ui/pull/4598